### PR TITLE
Add license and usage docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 The XORM Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,60 @@
-`XORM` (`⊕M`) is just xor, macros and 2 abstract 8-bit registers: `R1` and `R0`.
-Macros are the only abstraction allowed.
-XOR(⊕) is the only runtime instruction available, i.e. R0 ← R0 ⊕ R1
+# XORM (⊕M)
+
+XORM is a tiny DSL with exactly two 8‑bit registers `R1` and `R0` and a
+single runtime instruction `⊕` (`xor`).  Everything else is built using
+macros that expand to that primitive instruction.  Running a program
+produces a list of the final values of `R0` and `R1`.
+
+## Setup
+
+1. Install [Racket](https://racket-lang.org/) (version 8 or newer).
+2. Clone this repository and enter the directory.
+
+```
+$ git clone <repo-url>
+$ cd XORM
+```
+
+No additional packages are required – all files run with the default
+Racket distribution.
+
+## Example usage
+
+### `xorm.rkt`
+
+This file defines the XORM DSL and includes a small sample program at the
+bottom.  Running the file will execute that sample and print the resulting
+program and register values.
+
+```
+$ racket xorm.rkt
+```
+
+You can modify the sequence of `(do ...)` forms at the end of the file to
+experiment with the macros.  Each macro emits primitive instructions that
+are stored in `xorm-program` and executed by `run-xorm`.
+
+### `mrox.rkt`
+
+`mrox.rkt` is a very small "decompiler" that attempts to turn a sequence
+of primitive instructions back into the higher level macros.  Running the
+file will print the example program and the decompiled form:
+
+```
+$ racket mrox.rkt
+```
+
+## Running the tests
+
+Both `xorm.rkt` and `mrox.rkt` contain example programs at the bottom of
+their files.  Running them with `racket` acts as a simple test that the
+language and decompiler behave as expected.  Execute:
+
+```
+$ racket xorm.rkt
+$ racket mrox.rkt
+```
+
+The output should display the generated instruction list and the final
+register state for `xorm.rkt`, and a pretty‑printed decompilation for
+`mrox.rkt`.


### PR DESCRIPTION
## Summary
- add MIT LICENSE file
- expand README with setup instructions and usage for `xorm.rkt` and `mrox.rkt`

## Testing
- `racket xorm.rkt` *(fails: command not found)*
- `racket mrox.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4c304800832881a62192730c90ae