### PR TITLE
Fix decomp module dependencies

### DIFF
--- a/mrox.rkt
+++ b/mrox.rkt
@@ -1,5 +1,7 @@
 #lang racket
 
+(require racket/list)
+
 ;; ============================================================================
 ;; 🐂 MR. OX 🐂 - The XORM decompiler
 ;;


### PR DESCRIPTION
## Summary
- add a `racket/list` requirement to `mrox.rkt` so helpers like `filter-map` are available

## Testing
- `racket mrox.rkt`

------
https://chatgpt.com/codex/tasks/task_e_683f4c2e74b88328a43c2ae8908e589a