### PR TITLE
Export XORM DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 `XORM` (`⊕M`) is just xor, macros and 2 abstract 8-bit registers: `R1` and `R0`.
 Macros are the only abstraction allowed.
 XOR(⊕) is the only runtime instruction available, i.e. R0 ← R0 ⊕ R1
+
+To use the DSL in another Racket file:
+
+```racket
+(require "xorm.rkt")
+
+(module+ main
+  (do (set-r0 42))
+  (do (← 13))
+  (displayln (run-xorm xorm-program)))
+```
+

--- a/mrox.rkt
+++ b/mrox.rkt
@@ -141,8 +141,9 @@
     (← 255)     ; Set R1 to 255
     (⊕)))       ; XOR into R0 (dec-r0)
 
-(displayln "Original XORM program:")
-(for-each displayln example-program)
+(module+ main
+  (displayln "Original XORM program:")
+  (for-each displayln example-program)
 
-(displayln "\nDecompiled high-level macros:")
-(pretty-print-decompiled (decompile-xorm example-program))
+  (displayln "\nDecompiled high-level macros:")
+  (pretty-print-decompiled (decompile-xorm example-program)))

--- a/xorm.rkt
+++ b/xorm.rkt
@@ -1,4 +1,5 @@
 #lang racket
+(provide (all-defined-out))
 
 ;; ============================================================================
 ;; XORM DSL
@@ -211,18 +212,19 @@
     [(_ val)
       (bitwise-arithmetic-shift-right val 1)]))
 
-;; Testing
-(do (set-r0 42))     ; Set R0 to 42
-(do (← 13))          ; Set R1 to 13
-(do (add-r0-r1))     ; R0 = 42 + 13 = 55
-(do (inc-r0))        ; R0 = 55 + 1 = 56
-(do (dec-r0))        ; R0 = 56 - 1 = 55
-(do (← 127))         ; Set R1 to 127
-(do (and-r0-r1))     ; R0 = 55 & 127 = 55
-(do (← 72))          ; Set R1 to 72
-(do (or-r0-r1))      ; R0 = 55 | 72 = 127
-(do (shift-left-r0)) ; R0 = 127 << 1 = 254
-(do (shift-right-r0)); R0 = 254 >> 1 = 127
-(do (swap))          ; Swap R0 and R1, R0 = 72, R1 = 127
+;; Example usage when running this file directly
+(module+ main
+  (do (set-r0 42))     ; Set R0 to 42
+  (do (← 13))          ; Set R1 to 13
+  (do (add-r0-r1))     ; R0 = 42 + 13 = 55
+  (do (inc-r0))        ; R0 = 55 + 1 = 56
+  (do (dec-r0))        ; R0 = 56 - 1 = 55
+  (do (← 127))         ; Set R1 to 127
+  (do (and-r0-r1))     ; R0 = 55 & 127 = 55
+  (do (← 72))          ; Set R1 to 72
+  (do (or-r0-r1))      ; R0 = 55 | 72 = 127
+  (do (shift-left-r0)) ; R0 = 127 << 1 = 254
+  (do (shift-right-r0)); R0 = 254 >> 1 = 127
+  (do (swap))          ; Swap R0 and R1, R0 = 72, R1 = 127
 
-(list "(0 0) ↦" xorm-program '↦ (run-xorm xorm-program))
+  (displayln (list "(0 0) ↦" xorm-program '↦ (run-xorm xorm-program))))


### PR DESCRIPTION
## Summary
- provide all definitions from the XORM DSL module
- guard example code with `module+ main`
- show how to `require` the DSL in `README`

## Testing
- `raco make xorm.rkt` *(fails: `←: bad syntax`)*

------
https://chatgpt.com/codex/tasks/task_e_683f4c30e7988328b0f0d12a753ccd54