### PR TITLE
Add rackunit tests and expose DSL API

### DIFF
--- a/tests/core-tests.rkt
+++ b/tests/core-tests.rkt
@@ -1,0 +1,35 @@
+#lang racket
+(require rackunit
+         "../xorm.rkt")
+
+;; Test swap macro instruction sequence
+(test-case "swap expands correctly"
+  (reset-program!)
+  (do (swap))
+  (check-equal? xorm-program
+                '(⊕ (← 0) (← R0) ⊕ (← R1) ⊕)))
+
+;; Test clear-r0 macro
+(test-case "clear-r0 expands correctly"
+  (reset-program!)
+  (do (clear-r0))
+  (check-equal? xorm-program
+                '((← 0) (← 0) ⊕)))
+
+;; Test inc-r0 macro
+(test-case "inc-r0 expands correctly"
+  (reset-program!)
+  (do (inc-r0))
+  (check-equal? xorm-program
+                '((← 1) ⊕)))
+
+;; Test dec-r0 macro
+(test-case "dec-r0 expands correctly"
+  (reset-program!)
+  (do (dec-r0))
+  (check-equal? xorm-program
+                '((← 255) ⊕ (← 1) ⊕ (← 255) ⊕)))
+
+;; Provide tests for raco test
+(provide (all-defined-out))
+

--- a/xorm.rkt
+++ b/xorm.rkt
@@ -15,6 +15,18 @@
 ;; the XORM program
 (define xorm-program '())
 
+;; Export DSL constructs
+(provide
+  xorm-program emit run-xorm
+  xor ← set-r0 do swap clear-r0 clear-r1 inc-r0 dec-r0
+  copy-to-r1 not-r0 and-r0-r1 or-r0-r1 add-r0-r1
+  shift-left-r0 shift-right-r0 << >>
+  reset-program!)
+
+;; reset the recorded program
+(define (reset-program!)
+  (set! xorm-program '()))
+
 ;; append an instruction to the program
 (define (emit inst)
   (set! xorm-program (append xorm-program (list inst))))
@@ -30,7 +42,11 @@
                  (set! R0 (bitwise-xor R0 R1))]
                 [(and (list? inst)
                       (equal? (first inst) '←))
-                 (set! R1 (second inst))]
+                 (define val (second inst))
+                 (cond
+                   [(eq? val 'R0) (set! R1 R0)]
+                   [(eq? val 'R1) (set! R1 R1)]
+                   [else (set! R1 val)])]
                 [else (error "???" inst)]))
             prog)  
   (list R0 R1))
@@ -73,9 +89,9 @@
      (begin
        (xor)        ; R0 = R0 ⊕ R1
        (← 0)        ; R1 = 0
-       (← R0)       ; Set R1 to current R0
+       (← 'R0)      ; Set R1 to current R0
        (xor)        ; R0 = R0 ⊕ R0 = 0
-       (← R1)       ; Restore original R1 to R1
+       (← 'R1)      ; Restore original R1 to R1
        (xor))]))    ; R0 = 0 ⊕ R1 = original R1
 
 ;; clear-r0: Set R0 to 0
@@ -119,7 +135,7 @@
      (begin
        (← 0)      ; Set R1 to 0
        (xor)      ; R0 = R0 ⊕ 0 = R0
-       (← R0))]))  ; Set R1 to R0
+       (← 'R0))]))  ; Set R1 to R0
 
 ;; not-r0: Bitwise NOT of R0
 (define-syntax not-r0
@@ -150,17 +166,17 @@
      (begin
        ;; Save original R0 and R1
        (copy-to-r1)  ; Store R0 in R1
-       (← R1)        ; Get original R1
+       (← 'R1)       ; Get original R1
        ;; Compute A ⊕ B
        (xor)         ; R0 = R0 ⊕ R1
        ;; Save A ⊕ B
-       (← R0)        ; Save A ⊕ B in R1
+       (← 'R0)       ; Save A ⊕ B in R1
        ;; Compute A & B
-       (← R0)        ; R1 = R0 (original)
+       (← 'R0)       ; R1 = R0 (original)
        (and-r0-r1)   ; R0 = R0 & R1
        ;; Final step: (A ⊕ B) ⊕ (A & B)
-       (← R0)        ; Set R1 to A & B
-       (← R0)        ; Set R1 to A ⊕ B
+       (← 'R0)       ; Set R1 to A & B
+       (← 'R0)       ; Set R1 to A ⊕ B
        (xor))]))     ; R0 = (A ⊕ B) ⊕ (A & B) = A | B
 
 ;; add-r0-r1: Add R1 to R0, result in R0 (simple 8-bit addition)
@@ -169,12 +185,12 @@
     [(_)
      (begin
        (and-r0-r1)    ; R0 = R0 & R1 (get common 1 bits)
-       (← R0)         ; Store A & B
-       (← R1)         ; Get original R1
+       (← 'R0)        ; Store A & B
+       (← 'R1)        ; Get original R1
        (xor)          ; R0 = R0 ⊕ R1
-       (← R0)         ; Store A ⊕ B
-       (← R1)         ; Restore A & B
-       (← << R1)      ; Shift left (multiply by 2)
+       (← 'R0)        ; Store A ⊕ B
+       (← 'R1)        ; Restore A & B
+      (← (<< R1))     ; Shift left (multiply by 2)
        (xor))]))      ; R0 = (A ⊕ B) ⊕ ((A & B) << 1)
 
 ;; Shift R1 left by 1 bit
@@ -189,9 +205,9 @@
     [(_)
      (begin
        (copy-to-r1)    ; R1 = R0
-       (← << R1)       ; R1 = R0 << 1
+       (← (<< R1))     ; R1 = R0 << 1
        (set-r0 0)      ; Clear R0
-       (← R1)          ; Set R1 to shifted value
+       (← 'R1)         ; Set R1 to shifted value
        (xor))]))       ; R0 = 0 ⊕ R1 = R1
 
 ;; shift-right-r0: Shift R0 right by 1 bit, result in R0
@@ -200,9 +216,9 @@
     [(_)
      (begin
        (copy-to-r1)    ; R1 = R0
-       (← >> R1)       ; R1 = R0 >> 1
+       (← (>> R1))     ; R1 = R0 >> 1
        (set-r0 0)      ; Clear R0
-       (← R1)          ; Set R1 to shifted value
+       (← 'R1)         ; Set R1 to shifted value
        (xor))]))       ; R0 = 0 ⊕ R1 = R1
 
 ;; Shift R1 right by 1 bit
@@ -211,18 +227,19 @@
     [(_ val)
       (bitwise-arithmetic-shift-right val 1)]))
 
-;; Testing
-(do (set-r0 42))     ; Set R0 to 42
-(do (← 13))          ; Set R1 to 13
-(do (add-r0-r1))     ; R0 = 42 + 13 = 55
-(do (inc-r0))        ; R0 = 55 + 1 = 56
-(do (dec-r0))        ; R0 = 56 - 1 = 55
-(do (← 127))         ; Set R1 to 127
-(do (and-r0-r1))     ; R0 = 55 & 127 = 55
-(do (← 72))          ; Set R1 to 72
-(do (or-r0-r1))      ; R0 = 55 | 72 = 127
-(do (shift-left-r0)) ; R0 = 127 << 1 = 254
-(do (shift-right-r0)); R0 = 254 >> 1 = 127
-(do (swap))          ; Swap R0 and R1, R0 = 72, R1 = 127
 
-(list "(0 0) ↦" xorm-program '↦ (run-xorm xorm-program))
+;; Demonstration program (uncomment to run)
+#;(module+ main
+    (do (set-r0 42))
+    (do (← 13))
+    (do (add-r0-r1))
+    (do (inc-r0))
+    (do (dec-r0))
+    (do (← 127))
+    (do (and-r0-r1))
+    (do (← 72))
+    (do (or-r0-r1))
+    (do (shift-left-r0))
+    (do (shift-right-r0))
+    (do (swap))
+    (displayln (list "(0 0) ->" xorm-program '-> (run-xorm xorm-program))))


### PR DESCRIPTION
## Summary
- export API from `xorm.rkt` and add helper to reset program
- update macros to avoid unbound identifiers
- sanitize example usage section
- add rackunit-based tests for core macros

## Testing
- `raco test tests/core-tests.rkt`

------
https://chatgpt.com/codex/tasks/task_e_683f4c31b5bc8328be6ce79b2437bc83