### PR TITLE
Add runtime tests

### DIFF
--- a/tests/core-tests.rkt
+++ b/tests/core-tests.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (require rackunit
-         "../xorm.rkt")
+         "../xorm.rkt"
+         "runtime-tests.rkt")
 
 ;; Test swap macro instruction sequence
 (test-case "swap expands correctly"
@@ -31,5 +32,6 @@
                 '((← 255) ⊕ (← 1) ⊕ (← 255) ⊕)))
 
 ;; Provide tests for raco test
-(provide (all-defined-out))
+(provide (all-defined-out)
+         (all-from-out "runtime-tests.rkt"))
 

--- a/tests/runtime-tests.rkt
+++ b/tests/runtime-tests.rkt
@@ -1,0 +1,29 @@
+#lang racket
+(require rackunit
+         "../xorm.rkt")
+
+;; Runtime test for inc-r0
+(test-case "inc-r0 runtime"
+  (reset-program!)
+  (do (inc-r0))
+  (check-equal? (run-xorm xorm-program)
+                '(1 1)))
+
+;; Runtime test for dec-r0 starting from 5
+(test-case "dec-r0 runtime"
+  (reset-program!)
+  (do (set-r0 5)
+      (dec-r0))
+  (check-equal? (run-xorm xorm-program)
+                '(4 255)))
+
+;; Runtime test for add-r0-r1: 5 + 3 = 8
+(test-case "add-r0-r1 runtime"
+  (reset-program!)
+  (do (set-r0 5)
+      (← 3)
+      (add-r0-r1))
+  (check-equal? (run-xorm xorm-program)
+                '(8 0)))
+
+(provide (all-defined-out))


### PR DESCRIPTION
## Summary
- verify register state for runtime macros in new runtime-tests
- bring in runtime tests from core-tests

## Testing
- `raco test tests/core-tests.rkt` *(fails: add-r0-r1 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_684197bdc0d88328b28810c6c9fff706