### PR TITLE
Use cons-based emission in xorm and adjust tests for reverse storage

### DIFF
--- a/tests/core-tests.rkt
+++ b/tests/core-tests.rkt
@@ -7,7 +7,7 @@
 (test-case "swap expands correctly"
   (reset-program!)
   (do (swap))
-  (check-equal? xorm-program
+  (check-equal? (reverse xorm-program)
                 '(store-r1 (← 0) ⊕ (← R0) ⊕ load-r0-from-temp))
   )
 
@@ -15,7 +15,7 @@
 (test-case "clear-r0 expands correctly"
   (reset-program!)
   (do (clear-r0))
-  (check-equal? xorm-program
+  (check-equal? (reverse xorm-program)
                 '((← R0) ⊕ (← 0) ⊕))
   )
 
@@ -39,7 +39,7 @@
 (test-case "shift-left-r0 expands correctly"
   (reset-program!)
   (do (shift-left-r0))
-  (check-equal? xorm-program
+  (check-equal? (reverse xorm-program)
                 '((← 0) ⊕ (← R0) (← R1) (← R0) ⊕ ⊕ (← 0) ⊕))
   )
 
@@ -47,7 +47,7 @@
 (test-case "shift-right-r0 expands correctly"
   (reset-program!)
   (do (shift-right-r0))
-  (check-equal? xorm-program
+  (check-equal? (reverse xorm-program)
                 '((← 0) ⊕ (← R0) (← R1) (← R0) ⊕ ⊕ (← 0) ⊕))
   )
 

--- a/xorm.rkt
+++ b/xorm.rkt
@@ -61,7 +61,7 @@
 
 (define (emit inst)
   (validate-inst inst)
-  (set! xorm-program (append xorm-program (list inst))))
+  (set! xorm-program (cons inst xorm-program)))
 
 ;; run a XORM program
 (define (run-xorm prog)


### PR DESCRIPTION
### Motivation
- Emission using repeated `append` made program construction O(n^2) for many instructions and should be made O(1) per emit. 
- The program is already treated as reversed for execution, so a cons-based accumulation that stores instructions in reverse emission order preserves the external contract. 
- Tests that asserted on the internal storage order needed to be adjusted to assert on the forward order (i.e. `(reverse xorm-program)`).

### Description
- Replaced append-based emission with consing in `xorm.rkt` by changing the emitter to `(set! xorm-program (cons inst xorm-program))`, keeping `run-xorm`’s single reverse at execution time unchanged. 
- Updated `tests/core-tests.rkt` to compare emitted expansions against `(reverse xorm-program)` where appropriate so forward instruction order is asserted. 
- Left runtime and decompiler consumers unchanged because they already reverse or consume the program in forward order.

### Testing
- Attempted to run the test suite with `raco test tests/*.rkt`, but the run failed because `raco`/Racket is not installed in the environment, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54689cbf88328a20b19c5e6b5e22d)