### PR TITLE
Clarify set-r0 / clear-r0 register side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ The language is built entirely from macros that expand to the primitive
 
 - `xor` – perform `R0 ← R0 ⊕ R1`.
 - `← c` – set `R1` to the constant or register `c`.
-- `set-r0 c` – load the constant `c` into `R0`.
+- `set-r0 c` – load the constant `c` into `R0` **and overwrite `R1` with `c`**.
 - `do` – evaluate a sequence of operations.
 - `swap` – exchange the values of `R0` and `R1`.
-- `clear-r0` / `clear-r1` – set the respective register to zero.
+- `clear-r0` / `clear-r1` – set the respective register to zero (`clear-r0` also leaves `R1 = 0` because it expands through `set-r0`).
 - `inc-r0` / `dec-r0` – increment or decrement `R0`.
 - `copy-to-r1` – copy the current value of `R0` into `R1`.
 - `not-r0` – bitwise complement of `R0`.

--- a/xorm.rkt
+++ b/xorm.rkt
@@ -107,7 +107,7 @@
         (emit
           (list '← c)))]))
 
-;; set-r0: sets R0 to a constant
+;; set-r0: sets R0 to a constant (clobbers R1)
 (define-syntax set-r0
   (syntax-rules ()
     [(_ c)
@@ -115,7 +115,7 @@
         (← 'R0)   ; Copy current R0 into R1
         (xor)     ; Clear R0 by xoring it with itself
         (← c)     ; Load the requested constant
-        (xor))])) ; Apply it to R0
+        (xor))])) ; Apply it to R0; R1 remains c
 
 ;; run a list of operations
 (define-syntax do
@@ -134,7 +134,7 @@
        (xor)
        (emit 'load-r0-from-temp))]))
 
-;; clear-r0: Set R0 to 0
+;; clear-r0: Set R0 to 0 (also overwrites R1 with 0 via set-r0)
 (define-syntax clear-r0
   (syntax-rules ()
     [(_)


### PR DESCRIPTION
### Motivation
- Choose Option A: keep the existing `set-r0` implementation and make its side effects explicit in docs so users know `set-r0` leaves `R1` equal to the loaded constant.

### Description
- Update `xorm.rkt` comments to state that `set-r0` clobbers `R1` and that `clear-r0` overwrites `R1` via its expansion through `set-r0`, and update `README.md` macro descriptions to reflect the same behavior (files changed: `xorm.rkt`, `README.md`).

### Testing
- Ran the test command `raco test tests`, but the command failed in this environment with `raco: command not found`, so no test suite results are available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54688ad24832891092f660b4c94da)