### PR TITLE
Make shift macros emit explicit primitives and mark decompiler placeholders

### DIFF
--- a/mrox.rkt
+++ b/mrox.rkt
@@ -108,9 +108,9 @@
 
     (add-r0-r1 . ((set-carry 0) ADD))
 
-    (shift-left-r0 . ((← 0) ⊕ (← R0) (← R1) (← R0) ⊕ ⊕ (← 0) ⊕))
+    (shift-left-r0-placeholder . ((← 0) ⊕ (← R0) (← R1) (← R0) ⊕ ⊕ (← 0) ⊕))
 
-    (shift-right-r0 . ((← 0) ⊕ (← R0) (← R1) (← R0) ⊕ ⊕ (← 0) ⊕))
+    (shift-right-r0-placeholder . ((← 0) ⊕ (← R0) (← R1) (← R0) ⊕ ⊕ (← 0) ⊕))
   ))
 
 (define (decompile-xorm program)

--- a/xorm.rkt
+++ b/xorm.rkt
@@ -243,32 +243,36 @@
          (datum->syntax stx (bitwise-and (arithmetic-shift v 1) 255))
          #'val)]))
 
-;; shift-left-r0: Dummy left shift
+;; shift-left-r0: Placeholder left shift
 ;;
 ;; True shifting cannot be achieved with XOR alone.  This macro merely
-;; scrambles the registers using XOR and constants.
+;; emits a fixed primitive sequence that resembles a shift scaffold.
 (define-syntax shift-left-r0
   (syntax-rules ()
     [(_)
      (begin
-       (copy-to-r1)
-       (← (<< R1))
+       (← 0)
+       (xor)
+       (← 'R0)
+       (← 'R1)
        (← 'R0)
        (xor)
        (xor)
        (← 0)
        (xor))]))
 
-;; shift-right-r0: Dummy right shift
+;; shift-right-r0: Placeholder right shift
 ;;
 ;; Like the left shift, this macro does not actually shift bits.  It is kept
-;; for symmetry and uses only XOR and constant loads.
+;; for symmetry and emits an explicit primitive fallback sequence.
 (define-syntax shift-right-r0
   (syntax-rules ()
     [(_)
      (begin
-       (copy-to-r1)
-       (← (>> R1))
+       (← 0)
+       (xor)
+       (← 'R0)
+       (← 'R1)
        (← 'R0)
        (xor)
        (xor)


### PR DESCRIPTION
### Motivation

- Avoid ambiguous compile-time helper usage when emitting shift sequences on symbolic registers by producing an unambiguous primitive instruction stream. 
- Ensure the decompiler matches the exact emitted sequence and that shifts are explicitly documented as placeholders when true bit shifts are not implementable with the available primitives.

### Description

- Change `define-syntax shift-left-r0` in `xorm.rkt` to emit a fixed primitive sequence (explicit `←`/`⊕` pattern) and update the comment to mark it as a placeholder/fallback scaffold. 
- Change `define-syntax shift-right-r0` in `xorm.rkt` to emit a matching explicit primitive sequence and update its comment to indicate placeholder status. 
- Update `macro-patterns` in `mrox.rkt` so the decompiler entries mirror the emitted sequences and use distinct placeholder names `shift-left-r0-placeholder` and `shift-right-r0-placeholder`.

### Testing

- Attempted to load both modules with `racket -t xorm.rkt && racket -t mrox.rkt`, which could not run in this environment because `racket` is not installed (automated run failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f546882f7c832883368374d0c80953)