### PR TITLE
Expand run-xorm dispatcher and add 8-bit carry semantics

### DIFF
--- a/xorm.rkt
+++ b/xorm.rkt
@@ -72,14 +72,29 @@
   (define R0 0)
   (define R1 0)
   (define temp 0)
+  (define carry 0)
   (for-each (lambda (inst)
               (cond
                 [(eq? inst '⊕)
                  (set! R0 (mask-byte (bitwise-xor R0 R1)))]
+                [(eq? inst 'AND)
+                 (set! R0 (mask-byte (bitwise-and R0 R1)))]
+                [(eq? inst 'OR)
+                 (set! R0 (mask-byte (bitwise-ior R0 R1)))]
+                [(eq? inst 'ADD)
+                 (define sum (+ R0 R1 carry))
+                 (set! R0 (mask-byte sum))
+                 (set! carry (if (> sum 255) 1 0))]
+                [(eq? inst 'carry->r1)
+                 (set! R1 carry)]
                 [(eq? inst 'store-r1)
                  (set! temp (mask-byte R1))]
                 [(eq? inst 'load-r0-from-temp)
                  (set! R0 (mask-byte temp))]
+                [(and (list? inst)
+                      (equal? (first inst) 'set-carry))
+                 (define c (second inst))
+                 (set! carry (if (equal? c 0) 0 1))]
                 [(and (list? inst)
                       (equal? (first inst) '←))
                  (define val (second inst))
@@ -87,7 +102,9 @@
                    [(eq? val 'R0) (set! R1 (mask-byte R0))]
                    [(eq? val 'R1) (set! R1 (mask-byte R1))]
                    [else (set! R1 (mask-byte val))])]
-                [else (error "???" inst)]))
+                [else
+                 (error 'run-xorm
+                        (format "Unknown instruction in run-xorm: ~v" inst))]))
             (reverse prog))
   (list R0 R1))
 


### PR DESCRIPTION
### Motivation
- The macro layer emits additional runtime primitives beyond `⊕`, so the interpreter must dispatch these new instructions. 
- Arithmetic and bitwise operations should preserve 8-bit semantics and expose a carry flag for multi-step arithmetic sequences. 
- `set-carry` and `carry->r1` must be supported so macros can manipulate and observe carry state. 
- Unknown instructions should produce clearer, contextual errors to aid debugging. 

### Description
- Added an internal `carry` runtime variable to `run-xorm` and ensured all register results are masked to 8 bits via `mask-byte`. 
- Implemented instruction handlers for `AND`, `OR`, and `ADD` where `ADD` computes `sum = R0 + R1 + carry`, stores `R0 = sum & 0xFF`, and sets `carry = 1` when `sum > 255` else `0`. 
- Implemented `(set-carry c)` to normalize inputs to a 0/1 carry value and `carry->r1` to move the carry into `R1`. 
- Replaced the generic unknown-instruction failure with a clearer `error 'run-xorm` message that includes the offending instruction. 

### Testing
- Attempted to load the module with `racket -t xorm.rkt`, but execution failed because `racket` is not installed in this environment, so no runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54684ec348328bc00db4f2ec62f02)