### PR TITLE
Keep explicit XORM exports

### DIFF
--- a/xorm.rkt
+++ b/xorm.rkt
@@ -3,8 +3,6 @@
 (require rnrs/arithmetic/bitwise-6)
 (require (for-syntax syntax/parse))
 
-(provide (all-defined-out))
-
 
 ;; ============================================================================
 ;; XORM DSL


### PR DESCRIPTION
### Motivation
- Remove the accidental broad export so helper/private identifiers are not exported and the later explicit `provide` documents the intended public DSL surface.

### Description
- Delete the top-level `(provide (all-defined-out))` from `xorm.rkt` and retain the explicit `(provide ...)` list that enumerates the public DSL symbols.

### Testing
- Ran `git diff --check` (no issues) and attempted `raco test xorm.rkt` but `raco` is not installed in the environment so the test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3957781f48832898a040678659f7be)