### PR TITLE
Use symbol-form XOR in example program

### DIFF
--- a/mrox.rkt
+++ b/mrox.rkt
@@ -155,17 +155,17 @@
 
 (define example-program
   '((← 42)      ; Set R1 to 42
-    (⊕)         ; XOR into R0
+    ⊕           ; XOR into R0
     (← 13)      ; Set R1 to 13  
-    (⊕)         ; XOR into R0
+    ⊕           ; XOR into R0
     (← 1)       ; Set R1 to 1
-    (⊕)         ; XOR into R0 (inc-r0)
+    ⊕           ; XOR into R0 (inc-r0)
     (← 255)     ; Set R1 to 255
-    (⊕)         ; XOR into R0
+    ⊕           ; XOR into R0
     (← 1)       ; Set R1 to 1
-    (⊕)         ; XOR into R0
+    ⊕           ; XOR into R0
     (← 255)     ; Set R1 to 255
-    (⊕)))       ; XOR into R0 (dec-r0)
+    ⊕))         ; XOR into R0 (dec-r0)
 
 (module+ main
   (displayln "Original XORM program:")


### PR DESCRIPTION
### Motivation
- Align the `example-program` in `mrox.rkt` with emitted-program fixtures which use the symbol-form `⊕` instead of the list-form `(⊕)`.

### Description
- Replaced six occurrences of the list-form `(⊕)` with the symbol-form `⊕` inside the quoted `example-program` in `mrox.rkt`.
- Adjusted surrounding punctuation and spacing so the quoted list remains syntactically correct and matches the style used by `tests/core-tests.rkt` and `tests/decompiler-tests.rkt`.

### Testing
- Attempted to run `raco test mrox.rkt tests/core-tests.rkt tests/decompiler-tests.rkt`, but the test command failed because `raco` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39577a05e08328abab022800b9f2c2)